### PR TITLE
Revert "Fix issue with hocr metadata not being selectable by the indexer."

### DIFF
--- a/JfkWebApiSkills/JfkInitializer/indexer.json
+++ b/JfkWebApiSkills/JfkInitializer/indexer.json
@@ -34,7 +34,7 @@
             "targetFieldName": "text"
         },
         {
-            "sourceFieldName": "/document/hocrDocument/Metadata",
+            "sourceFieldName": "/document/hocrDocument/metadata",
             "targetFieldName": "metadata"
         },
         {


### PR DESCRIPTION
This reverts commit 164e582ca5019d359650909369fd06778c4fa0ea.

This fixed the issues reported in #22 and #24 for me.