### PR TITLE
Fix TLS issue with Azure functions temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ These instructions will help you have your own version of the JFK files demo run
     5. An Azure Function instance, using the storage account from # 2 and the plan from # 3.  The Azure Function will be prepublished with the code provided in this repository as part of the template deployment.
 
     </br>
-    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FAzureSearch_JFK_Files%2Fmaster%2Fazuredeploy.json" target="_blank">
+    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FAzureSearch_JFK_Files%2FfixTLS%2Fazuredeploy.json" target="_blank">
         <img src="http://azuredeploy.net/deploybutton.png"/>
     </a>
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ These instructions will help you have your own version of the JFK files demo run
     5. An Azure Function instance, using the storage account from # 2 and the plan from # 3.  The Azure Function will be prepublished with the code provided in this repository as part of the template deployment.
 
     </br>
-    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FAzureSearch_JFK_Files%2FfixTLS%2Fazuredeploy.json" target="_blank">
+    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FAzureSearch_JFK_Files%2Fmaster%2Fazuredeploy.json" target="_blank">
         <img src="http://azuredeploy.net/deploybutton.png"/>
     </a>
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -170,7 +170,7 @@
                         ]
                     }
                 },
-                "minTlsVersion": "1.0"
+                "minTlsVersion": 1.0
             },
             "resources": [
                 {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -169,7 +169,8 @@
                             "[concat('https://', variables('websiteName'), '.azurewebsites.net')]"
                         ]
                     }
-                }
+                },
+                "minTlsVersion": "1.0"
             },
             "resources": [
                 {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -168,9 +168,9 @@
                         "allowedOrigins": [
                             "[concat('https://', variables('websiteName'), '.azurewebsites.net')]"
                         ]
-                    }
-                },
-                "minTlsVersion": 1.0
+                    },
+                    "minTlsVersion": "1.0"
+                }
             },
             "resources": [
                 {


### PR DESCRIPTION
Unfortunately, the recently changed default Azure Function TLS settings are incompatible with custom skills. Please see this blog post for more information. https://blogs.msdn.microsoft.com/appserviceteam/2018/04/17/app-service-and-functions-hosted-apps-can-now-update-tls-versions/

This change sets the TLS version to one that is currently supported by our infrastructure.  I will revert this change once  the proper solution of custom skills supporting TLS 1.2 has been deployed, but for now this will unblock people trying to run the demo.