### PR TITLE
Deploy Azure Search to resource group location

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -118,7 +118,7 @@
             "apiVersion": "2015-08-19",
             "name": "[variables('searchServiceName')]",
             "type": "Microsoft.Search/searchServices",
-            "location": "southcentralus",
+            "location": "[resourceGroup().location]",
             "sku": {
                 "name": "[parameters('searchServiceSku')]"
             }


### PR DESCRIPTION
This became especially noticeable with the recent South Central US outage. Unless there's a specific reason to put this in South Central, we might as well default to the resource group location.