### PR TITLE
Fix compile issue #92

### DIFF
--- a/frontend/src/pages/search-page/search-page.container.tsx
+++ b/frontend/src/pages/search-page/search-page.container.tsx
@@ -37,7 +37,7 @@ class SearchPageInnerContainer extends React.Component<RouteComponentProps<any>,
       this.setState(restoreLastState());
     } else if (this.props.location.search) {
       const receivedSearchValue = parse(this.props.location.search.substring(1));
-      this.handleReceivedSearchValue(receivedSearchValue.term);
+      this.handleReceivedSearchValue(receivedSearchValue.term.toString());
     }
   }
 


### PR DESCRIPTION
Fixes #92. handleReceivedSearchValue takes a 'string' but receivedSearchValue.term could be of other types. This started happening likely after a npm dependency revved up and broke it without noticing. 