### PR TITLE
Update @types/d3 to 4.13.12 to fix compilation error

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "react-router-dom": "^4.2.2"
   },
   "devDependencies": {
-    "@types/d3": "4.13.0",
+    "@types/d3": "4.13.12",
     "@types/history": "^4.6.1",
     "@types/node": "^9.6.2",
     "@types/qs": "^6.5.1",


### PR DESCRIPTION
Update @types/d3 to 4.13.12 to fix compilation error in d3.event.