### PR TITLE
Add @types/react-router dev dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "@types/qs": "^6.5.1",
     "@types/react": "^16.0.21",
     "@types/react-dom": "^16.0.2",
+    "@types/react-router": "^4.3.1",
     "@types/react-router-dom": "^4.2.0",
     "awesome-typescript-loader": "^3.3.0",
     "babel-core": "^6.26.0",


### PR DESCRIPTION
@types/react-router-dom was bringing in @types/react-router@5.1.11 as a dependency, but those types don't match the version of react-router used. 

Now there's an explicit dependency on @types/react-router, pulling the right types version.